### PR TITLE
refactor: remove unused replaceProcess option from claude-launcher

### DIFF
--- a/src/claude-launcher.ts
+++ b/src/claude-launcher.ts
@@ -5,13 +5,11 @@ import { formatErrorMessage } from "./utils.js";
 export interface LaunchOptions {
   selectedConfigs: McpConfig[];
   passthroughArgs: string[];
-  replaceProcess?: boolean;
 }
 
 export async function launchClaudeCode({
   selectedConfigs,
   passthroughArgs,
-  replaceProcess = true,
 }: LaunchOptions): Promise<number> {
   const args: string[] = [];
 
@@ -23,108 +21,64 @@ export async function launchClaudeCode({
   // Add any passthrough arguments
   args.push(...passthroughArgs);
 
-  if (replaceProcess) {
-    // Replace the current process with Claude Code using exec syscall
-    try {
-      // Find the claude executable path
-      const claudePath = execFileSync("which", ["claude"], {
-        encoding: "utf8",
-        stdio: "pipe",
-      }).trim();
+  // Replace the current process with Claude Code using exec syscall
+  try {
+    // Find the claude executable path
+    const claudePath = execFileSync("which", ["claude"], {
+      encoding: "utf8",
+      stdio: "pipe",
+    }).trim();
 
-      console.log(`Executing: ${claudePath} ${args.join(" ")}`);
+    console.log(`Executing: ${claudePath} ${args.join(" ")}`);
 
-      // Flush stdio to ensure clean handover
-      process.stdout.write("");
-      process.stderr.write("");
+    // Flush stdio to ensure clean handover
+    process.stdout.write("");
+    process.stderr.write("");
 
-      // Build command with proper shell escaping
-      const escapeShellArg = (arg: string): string => {
-        return `"${arg.replace(/[\\"$`]/g, "\\$&")}"`;
-      };
-      const escapedArgs = args.map(escapeShellArg);
-      const command = `exec "${claudePath.replace(/[\\"$`]/g, "\\$&")}" ${escapedArgs.join(" ")}`;
+    // Build command with proper shell escaping
+    const escapeShellArg = (arg: string): string => {
+      return `"${arg.replace(/[\\"$`]/g, "\\$&")}"`;
+    };
+    const escapedArgs = args.map(escapeShellArg);
+    const command = `exec "${claudePath.replace(/[\\"$`]/g, "\\$&")}" ${escapedArgs.join(" ")}`;
 
-      // Use Node.js spawn with exec for true process replacement
-      // This provides better terminal control and keyboard input handling
-      const proc = spawn("sh", ["-c", command], {
-        stdio: "inherit",
-      });
-
-      // Exit with the same code as Claude Code
-      proc.on("exit", (code, signal) => {
-        if (signal) {
-          process.kill(process.pid, signal);
-        } else {
-          process.exit(code ?? 0);
-        }
-      });
-
-      // Handle errors
-      proc.on("error", (error) => {
-        console.error(`Error: Failed to exec Claude Code: ${error.message}`);
-        process.exit(1);
-      });
-
-      // This function should not return since we're replacing the process
-      return new Promise<number>(() => {});
-    } catch (error: unknown) {
-      const errorWithStatus = error as { status?: number; message?: string };
-      const isCommandNotFound =
-        errorWithStatus.status === 1 ||
-        errorWithStatus.message?.includes("command not found");
-
-      if (isCommandNotFound) {
-        console.error(
-          "Error: 'claude' command not found. Please ensure Claude Code is installed and in your PATH.",
-        );
-      } else {
-        const errorMessage = formatErrorMessage(error);
-        console.error(`Error: Failed to exec Claude Code: ${errorMessage}`);
-      }
-      return Promise.resolve(1);
-    }
-  } else {
-    // Spawn as child process (original behavior)
-    console.log(`Launching: claude ${args.join(" ")}`);
-
-    return new Promise<number>((resolve) => {
-      const child = spawn("claude", args, {
-        stdio: "inherit",
-        shell: false,
-      });
-
-      child.on("error", (error: NodeJS.ErrnoException) => {
-        if (error.code === "ENOENT") {
-          console.error(
-            "Error: 'claude' command not found. Please ensure Claude Code is installed and in your PATH.",
-          );
-          resolve(1);
-        } else {
-          console.error(
-            `Error: Failed to launch Claude Code: ${error.message}`,
-          );
-          resolve(1);
-        }
-      });
-
-      child.on("exit", (code, signal) => {
-        if (signal) {
-          console.log(`Claude Code terminated by signal: ${signal}`);
-          resolve(1);
-        } else {
-          resolve(code ?? 0);
-        }
-      });
-
-      // Handle graceful shutdown
-      const handleShutdown = (signal: NodeJS.Signals) => {
-        console.log(`\nReceived ${signal}, terminating Claude Code...`);
-        child.kill(signal);
-      };
-
-      process.once("SIGINT", handleShutdown);
-      process.once("SIGTERM", handleShutdown);
+    // Use Node.js spawn with exec for true process replacement
+    // This provides better terminal control and keyboard input handling
+    const proc = spawn("sh", ["-c", command], {
+      stdio: "inherit",
     });
+
+    // Exit with the same code as Claude Code
+    proc.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code ?? 0);
+      }
+    });
+
+    // Handle errors
+    proc.on("error", (error) => {
+      console.error(`Error: Failed to exec Claude Code: ${error.message}`);
+      process.exit(1);
+    });
+
+    // This function should not return since we're replacing the process
+    return new Promise<number>(() => {});
+  } catch (error: unknown) {
+    const errorWithStatus = error as { status?: number; message?: string };
+    const isCommandNotFound =
+      errorWithStatus.status === 1 ||
+      errorWithStatus.message?.includes("command not found");
+
+    if (isCommandNotFound) {
+      console.error(
+        "Error: 'claude' command not found. Please ensure Claude Code is installed and in your PATH.",
+      );
+    } else {
+      const errorMessage = formatErrorMessage(error);
+      console.error(`Error: Failed to exec Claude Code: ${errorMessage}`);
+    }
+    return Promise.resolve(1);
   }
 }


### PR DESCRIPTION
## Summary

- Remove unused `replaceProcess` parameter from `LaunchOptions` interface
- Remove unused `replaceProcess` parameter from `launchClaudeCode` function  
- Eliminate ~46 lines of dead child process spawning code
- Simplify function to use only process replacement approach

## Problem

The `launchClaudeCode` function had two execution paths:
1. Process replacement (when `replaceProcess = true`, which is the default)
2. Child process spawning (when `replaceProcess = false`)

However, analysis showed that all callers use the default value, making the child process code path unreachable dead code.

## Benefits

- **Reduces complexity** by removing ~46 lines of dead code
- **Improves maintainability** by eliminating unused code paths
- **Clarifies intent** - function now has single, clear purpose
- **Reduces cognitive load** for future developers

## Test plan

- [x] All existing tests continue to pass
- [x] Code quality checks (lint, format, type-check) pass
- [x] No breaking changes to public API

Fixes #23