### PR TITLE
feat: display version number in TUI header

### DIFF
--- a/src/console-selector.ts
+++ b/src/console-selector.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
 import { render } from "ink";
 import React from "react";
 import type { McpConfig } from "./mcp-scanner.js";
@@ -36,12 +39,20 @@ export async function selectConfigs(
 
   // Use Ink TUI if we're in a TTY environment
   if (isTTY()) {
+    // Read version from package.json
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, "../package.json"), "utf8"),
+    );
+    const version = packageJson.version as string;
+
     return new Promise<McpConfig[]>((resolve) => {
       const { waitUntilExit } = render(
         React.createElement(ConfigSelector, {
           configs,
           configDir,
           previouslySelected,
+          version,
           onSelect: (selectedConfigs: McpConfig[]) => {
             // Wait for TUI to fully exit before resolving
             waitUntilExit().then(() => {

--- a/src/tui/ConfigSelector.tsx
+++ b/src/tui/ConfigSelector.tsx
@@ -10,6 +10,7 @@ interface ConfigSelectorProps {
   onSelect: (selectedConfigs: McpConfig[]) => void;
   configDir: string;
   previouslySelected?: Set<string>;
+  version?: string;
 }
 
 export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
@@ -17,6 +18,7 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
   onSelect,
   configDir,
   previouslySelected = new Set(),
+  version,
 }) => {
   const { exit } = useApp();
   const validConfigs = configs.filter((config) => config.valid);
@@ -161,7 +163,9 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
     <Box flexDirection="column" height="100%">
       {/* Header */}
       <Box flexDirection="column" marginBottom={1}>
-        <Text bold>Available MCP Configs</Text>
+        <Text bold>
+          Available MCP Configs{version && ` - ccmcp v${version}`}
+        </Text>
         <Text>
           Use ↑/↓ to navigate, Space to select/deselect, Enter to confirm
         </Text>


### PR DESCRIPTION
## Summary
- Adds package version to the ConfigSelector TUI header (e.g., "Available MCP Configs - ccmcp v0.5.0")
- Reads version from package.json at runtime
- Improves user visibility of which version they're running

## Test plan
- [ ] Run `pnpm run dev` and verify version appears in TUI header
- [ ] Verify TUI functionality remains unchanged