### PR TITLE
feat: add cleanup command to remove stale configurations

### DIFF
--- a/src/__tests__/cleanup.test.ts
+++ b/src/__tests__/cleanup.test.ts
@@ -1,0 +1,194 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { cleanupCache } from "../cleanup.js";
+import { clearCache, getCacheDir, saveSelections } from "../selection-cache.js";
+
+describe.sequential("cleanupCache", () => {
+  let testConfigDir: string;
+
+  beforeEach(async () => {
+    await clearCache();
+    testConfigDir = join(tmpdir(), `ccmcp-cleanup-test-${Date.now()}`);
+    await mkdir(testConfigDir, { recursive: true });
+
+    const cacheDir = getCacheDir();
+    await mkdir(cacheDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await clearCache();
+  });
+
+  test("removes stale cache entries for non-existent projects", async () => {
+    const testBase = join(tmpdir(), `ccmcp-test-${Date.now()}`);
+    await mkdir(testBase, { recursive: true });
+
+    const existingProject = join(testBase, "existing");
+    const deletedProject = join(testBase, "deleted");
+
+    await mkdir(existingProject, { recursive: true });
+
+    const config1 = join(testConfigDir, "config1.json");
+    const config2 = join(testConfigDir, "config2.json");
+    await writeFile(config1, JSON.stringify({ mcpServers: {} }), "utf-8");
+    await writeFile(config2, JSON.stringify({ mcpServers: {} }), "utf-8");
+
+    await saveSelections(existingProject, testConfigDir, ["config1"]);
+    await saveSelections(deletedProject, testConfigDir, ["config2"]);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.staleCacheEntries).toBe(1);
+    expect(result.totalCacheFilesBefore).toBe(2);
+    expect(result.totalCacheFilesAfter).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("removes cache file when all server references are invalid", async () => {
+    const testBase = join(
+      tmpdir(),
+      `ccmcp-test-all-invalid-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+    );
+    await mkdir(testBase, { recursive: true });
+    const testProject = join(testBase, "project");
+    await mkdir(testProject, { recursive: true });
+
+    await saveSelections(testProject, testConfigDir, ["invalid1", "invalid2"]);
+
+    const cacheCountBefore = (
+      await cleanupCache({
+        configDir: testConfigDir,
+        dryRun: true,
+        yes: true,
+        verbose: false,
+      })
+    ).totalCacheFilesBefore;
+
+    await saveSelections(testProject, testConfigDir, ["invalid1", "invalid2"]);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.totalCacheFilesAfter).toBeLessThanOrEqual(cacheCountBefore);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("detects and removes broken symlinks", async () => {
+    const brokenLink = join(testConfigDir, "broken.json");
+    const nonExistentTarget = join(tmpdir(), "non-existent.json");
+
+    await symlink(nonExistentTarget, brokenLink);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.brokenSymlinks).toBe(1);
+  });
+
+  test("does not remove valid symlinks", async () => {
+    const validTarget = join(tmpdir(), `valid-target-${Date.now()}.json`);
+    const validLink = join(testConfigDir, "valid.json");
+
+    await writeFile(validTarget, JSON.stringify({ mcpServers: {} }), "utf-8");
+    await symlink(validTarget, validLink);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.brokenSymlinks).toBe(0);
+  });
+
+  test("handles empty cache directory gracefully", async () => {
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.brokenSymlinks).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("handles non-existent config directory gracefully", async () => {
+    const nonExistentDir = join(tmpdir(), `non-existent-${Date.now()}`);
+
+    const result = await cleanupCache({
+      configDir: nonExistentDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.brokenSymlinks).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("preserves valid cache entries", async () => {
+    const validProject = join(tmpdir(), `valid-${Date.now()}`);
+    await mkdir(validProject, { recursive: true });
+
+    const validConfig = join(testConfigDir, "valid.json");
+    await writeFile(validConfig, JSON.stringify({ mcpServers: {} }), "utf-8");
+
+    await saveSelections(validProject, testConfigDir, ["valid"]);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.totalCacheFilesAfter).toBeGreaterThanOrEqual(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("reports multiple types of issues in single run", async () => {
+    const validProject = join(tmpdir(), `valid-${Date.now()}`);
+    const deletedProject = join(tmpdir(), `deleted-${Date.now()}`);
+
+    await mkdir(validProject, { recursive: true });
+
+    const validConfig = join(testConfigDir, "valid.json");
+    await writeFile(validConfig, JSON.stringify({ mcpServers: {} }), "utf-8");
+
+    await saveSelections(validProject, testConfigDir, ["valid", "invalid"]);
+    await saveSelections(deletedProject, testConfigDir, ["config"]);
+
+    const brokenLink = join(testConfigDir, "broken.json");
+    const nonExistentTarget = join(tmpdir(), "non-existent.json");
+    await symlink(nonExistentTarget, brokenLink);
+
+    const result = await cleanupCache({
+      configDir: testConfigDir,
+      dryRun: false,
+      yes: true,
+      verbose: false,
+    });
+
+    expect(result.staleCacheEntries).toBe(1);
+    expect(result.invalidServerReferences).toBe(1);
+    expect(result.brokenSymlinks).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/__tests__/cli-ux.test.ts
+++ b/src/__tests__/cli-ux.test.ts
@@ -161,12 +161,12 @@ describe("CLI User Experience", () => {
       const originalArgv = process.argv;
 
       try {
-        process.argv = ["node", "ccmcp", "--resume", "--verbose"];
+        process.argv = ["node", "ccmcp", "--resume", "--debug"];
 
         const { parseCliArgs } = await import("../index.js");
         const result = parseCliArgs();
 
-        expect(result.positionals).toEqual(["--resume", "--verbose"]);
+        expect(result.positionals).toEqual(["--resume", "--debug"]);
       } finally {
         process.argv = originalArgv;
       }
@@ -176,20 +176,13 @@ describe("CLI User Experience", () => {
       const originalArgv = process.argv;
 
       try {
-        process.argv = [
-          "node",
-          "ccmcp",
-          "-c",
-          "/path",
-          "--resume",
-          "--verbose",
-        ];
+        process.argv = ["node", "ccmcp", "-c", "/path", "--resume", "--debug"];
 
         const { parseCliArgs } = await import("../index.js");
         const result = parseCliArgs();
 
         expect(result.values["config-dir"]).toBe("/path");
-        expect(result.positionals).toEqual(["--resume", "--verbose"]);
+        expect(result.positionals).toEqual(["--resume", "--debug"]);
       } finally {
         process.argv = originalArgv;
       }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,0 +1,408 @@
+import {
+  access,
+  readdir,
+  readFile,
+  readlink,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { getCacheDir, type SelectionCache } from "./selection-cache.js";
+
+export interface CleanupOptions {
+  configDir: string;
+  dryRun?: boolean;
+  yes?: boolean;
+  verbose?: boolean;
+}
+
+export interface CleanupResult {
+  staleCacheEntries: number;
+  invalidServerReferences: number;
+  brokenSymlinks: number;
+  totalCacheFilesBefore: number;
+  totalCacheFilesAfter: number;
+  errors: string[];
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isSymlinkBroken(filePath: string): Promise<boolean> {
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isSymbolicLink()) {
+      return false;
+    }
+
+    const target = await readlink(filePath);
+    const targetPath = target.startsWith("/")
+      ? target
+      : join(filePath, "..", target);
+
+    return !(await fileExists(targetPath));
+  } catch {
+    return true;
+  }
+}
+
+async function getAllCacheFiles(): Promise<string[]> {
+  const cacheDir = getCacheDir();
+  try {
+    const files = await readdir(cacheDir);
+    return files
+      .filter(
+        (file) => file.startsWith("selections-") && file.endsWith(".json"),
+      )
+      .map((file) => join(cacheDir, file));
+  } catch {
+    return [];
+  }
+}
+
+async function loadCacheFile(filePath: string): Promise<SelectionCache | null> {
+  try {
+    const content = await readFile(filePath, "utf-8");
+    const cache: SelectionCache = JSON.parse(content);
+
+    if (cache.version !== 1) {
+      return null;
+    }
+
+    return cache;
+  } catch {
+    return null;
+  }
+}
+
+async function promptUser(message: string): Promise<boolean> {
+  const readline = await import("node:readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`${message} [Y/n] `, (answer) => {
+      rl.close();
+      const normalized = answer.trim().toLowerCase();
+      resolve(normalized === "" || normalized === "y" || normalized === "yes");
+    });
+  });
+}
+
+async function cleanupStaleCacheEntries(
+  options: CleanupOptions,
+  result: CleanupResult,
+): Promise<void> {
+  const cacheFiles = await getAllCacheFiles();
+  const staleFiles: Array<{ path: string; projectDir: string }> = [];
+
+  for (const filePath of cacheFiles) {
+    const cache = await loadCacheFile(filePath);
+    if (!cache) continue;
+
+    const projectExists = await fileExists(cache.projectDir);
+    if (!projectExists) {
+      staleFiles.push({ path: filePath, projectDir: cache.projectDir });
+    }
+  }
+
+  if (staleFiles.length === 0) {
+    if (options.verbose) {
+      console.log("No stale cache entries found.");
+    }
+    return;
+  }
+
+  if (!options.yes) {
+    console.log(
+      `\nFound ${staleFiles.length} stale cache ${staleFiles.length === 1 ? "entry" : "entries"}:`,
+    );
+    for (const { projectDir } of staleFiles) {
+      console.log(`  - ${projectDir} (doesn't exist)`);
+    }
+    console.log("");
+
+    if (options.dryRun) {
+      console.log("[DRY RUN] Would remove these cache entries");
+      result.staleCacheEntries = staleFiles.length;
+      return;
+    }
+
+    const shouldProceed = await promptUser("Remove these cache entries?");
+    if (!shouldProceed) {
+      console.log("Skipped removing stale cache entries.");
+      return;
+    }
+  }
+
+  if (options.dryRun) {
+    console.log(
+      `[DRY RUN] Would remove ${staleFiles.length} stale cache ${staleFiles.length === 1 ? "entry" : "entries"}`,
+    );
+    result.staleCacheEntries = staleFiles.length;
+    return;
+  }
+
+  for (const { path } of staleFiles) {
+    try {
+      await rm(path, { force: true });
+      result.staleCacheEntries++;
+      if (options.verbose) {
+        console.log(`Removed: ${path}`);
+      }
+    } catch (error) {
+      result.errors.push(`Failed to remove ${path}: ${error}`);
+    }
+  }
+
+  if (options.verbose && result.staleCacheEntries > 0) {
+    console.log(
+      `Removed ${result.staleCacheEntries} stale cache ${result.staleCacheEntries === 1 ? "entry" : "entries"}.`,
+    );
+  }
+}
+
+async function cleanupInvalidServerReferences(
+  options: CleanupOptions,
+  result: CleanupResult,
+): Promise<void> {
+  const cacheFiles = await getAllCacheFiles();
+  const filesToUpdate: Array<{
+    path: string;
+    cache: SelectionCache;
+    invalidConfigs: string[];
+  }> = [];
+
+  for (const filePath of cacheFiles) {
+    const cache = await loadCacheFile(filePath);
+    if (!cache) continue;
+
+    const projectExists = await fileExists(cache.projectDir);
+    if (!projectExists) continue;
+
+    const invalidConfigs: string[] = [];
+    for (const configName of cache.selectedConfigs) {
+      const configPath = join(cache.configDir, `${configName}.json`);
+      const exists = await fileExists(configPath);
+      if (!exists) {
+        invalidConfigs.push(configName);
+      }
+    }
+
+    if (invalidConfigs.length > 0) {
+      filesToUpdate.push({ path: filePath, cache, invalidConfigs });
+    }
+  }
+
+  if (filesToUpdate.length === 0) {
+    if (options.verbose) {
+      console.log("No invalid server references found.");
+    }
+    return;
+  }
+
+  if (!options.yes) {
+    console.log(
+      `\nFound invalid server references in ${filesToUpdate.length} cache ${filesToUpdate.length === 1 ? "file" : "files"}:`,
+    );
+    for (const { cache, invalidConfigs } of filesToUpdate) {
+      console.log(`  - ${cache.projectDir}:`);
+      for (const config of invalidConfigs) {
+        console.log(`    • ${config} (config file doesn't exist)`);
+      }
+    }
+    console.log("");
+
+    if (options.dryRun) {
+      const totalInvalid = filesToUpdate.reduce(
+        (sum, f) => sum + f.invalidConfigs.length,
+        0,
+      );
+      console.log(
+        `[DRY RUN] Would remove ${totalInvalid} invalid ${totalInvalid === 1 ? "reference" : "references"}`,
+      );
+      result.invalidServerReferences = totalInvalid;
+      return;
+    }
+
+    const shouldProceed = await promptUser(
+      "Update cache files to remove invalid references?",
+    );
+    if (!shouldProceed) {
+      console.log("Skipped removing invalid server references.");
+      return;
+    }
+  }
+
+  if (options.dryRun) {
+    const totalInvalid = filesToUpdate.reduce(
+      (sum, f) => sum + f.invalidConfigs.length,
+      0,
+    );
+    console.log(
+      `[DRY RUN] Would remove ${totalInvalid} invalid ${totalInvalid === 1 ? "reference" : "references"}`,
+    );
+    result.invalidServerReferences = totalInvalid;
+    return;
+  }
+
+  for (const { path, cache, invalidConfigs } of filesToUpdate) {
+    try {
+      const validConfigs = cache.selectedConfigs.filter(
+        (config) => !invalidConfigs.includes(config),
+      );
+
+      if (validConfigs.length === 0) {
+        await rm(path, { force: true });
+        if (options.verbose) {
+          console.log(
+            `Removed cache file (no valid configs remaining): ${path}`,
+          );
+        }
+      } else {
+        const updatedCache: SelectionCache = {
+          ...cache,
+          selectedConfigs: validConfigs,
+          lastModified: new Date().toISOString(),
+        };
+        await writeFile(path, JSON.stringify(updatedCache, null, 2), "utf-8");
+        if (options.verbose) {
+          console.log(
+            `Updated: ${path} (removed ${invalidConfigs.length} invalid ${invalidConfigs.length === 1 ? "reference" : "references"})`,
+          );
+        }
+      }
+
+      result.invalidServerReferences += invalidConfigs.length;
+    } catch (error) {
+      result.errors.push(`Failed to update ${path}: ${error}`);
+    }
+  }
+
+  if (options.verbose && result.invalidServerReferences > 0) {
+    console.log(
+      `Removed ${result.invalidServerReferences} invalid server ${result.invalidServerReferences === 1 ? "reference" : "references"}.`,
+    );
+  }
+}
+
+async function cleanupBrokenSymlinks(
+  options: CleanupOptions,
+  result: CleanupResult,
+): Promise<void> {
+  try {
+    const files = await readdir(options.configDir);
+    const jsonFiles = files.filter((file) => file.endsWith(".json"));
+    const brokenLinks: string[] = [];
+
+    for (const file of jsonFiles) {
+      const filePath = join(options.configDir, file);
+      const isBroken = await isSymlinkBroken(filePath);
+      if (isBroken) {
+        brokenLinks.push(filePath);
+      }
+    }
+
+    if (brokenLinks.length === 0) {
+      if (options.verbose) {
+        console.log("No broken symlinks found.");
+      }
+      return;
+    }
+
+    if (!options.yes) {
+      console.log(
+        `\nFound ${brokenLinks.length} broken ${brokenLinks.length === 1 ? "symlink" : "symlinks"}:`,
+      );
+      for (const link of brokenLinks) {
+        console.log(`  - ${link}`);
+      }
+      console.log("");
+
+      if (options.dryRun) {
+        console.log(
+          `[DRY RUN] Would remove ${brokenLinks.length} broken ${brokenLinks.length === 1 ? "symlink" : "symlinks"}`,
+        );
+        result.brokenSymlinks = brokenLinks.length;
+        return;
+      }
+
+      const shouldProceed = await promptUser("Remove these broken symlinks?");
+      if (!shouldProceed) {
+        console.log("Skipped removing broken symlinks.");
+        return;
+      }
+    }
+
+    if (options.dryRun) {
+      console.log(
+        `[DRY RUN] Would remove ${brokenLinks.length} broken ${brokenLinks.length === 1 ? "symlink" : "symlinks"}`,
+      );
+      result.brokenSymlinks = brokenLinks.length;
+      return;
+    }
+
+    for (const link of brokenLinks) {
+      try {
+        await rm(link, { force: true });
+        result.brokenSymlinks++;
+        if (options.verbose) {
+          console.log(`Removed: ${link}`);
+        }
+      } catch (error) {
+        result.errors.push(`Failed to remove ${link}: ${error}`);
+      }
+    }
+
+    if (options.verbose && result.brokenSymlinks > 0) {
+      console.log(
+        `Removed ${result.brokenSymlinks} broken ${result.brokenSymlinks === 1 ? "symlink" : "symlinks"}.`,
+      );
+    }
+  } catch (error) {
+    if (options.verbose) {
+      console.log(`Could not scan config directory: ${error}`);
+    }
+  }
+}
+
+export async function cleanupCache(
+  options: CleanupOptions,
+): Promise<CleanupResult> {
+  const result: CleanupResult = {
+    staleCacheEntries: 0,
+    invalidServerReferences: 0,
+    brokenSymlinks: 0,
+    totalCacheFilesBefore: 0,
+    totalCacheFilesAfter: 0,
+    errors: [],
+  };
+
+  const cacheFilesBefore = await getAllCacheFiles();
+  result.totalCacheFilesBefore = cacheFilesBefore.length;
+
+  if (options.verbose) {
+    console.log(`Starting cleanup${options.dryRun ? " (DRY RUN)" : ""}...`);
+    console.log(`Config directory: ${options.configDir}`);
+    console.log(`Cache directory: ${getCacheDir()}`);
+    console.log(`Current cache files: ${result.totalCacheFilesBefore}\n`);
+  }
+
+  await cleanupStaleCacheEntries(options, result);
+  await cleanupInvalidServerReferences(options, result);
+  await cleanupBrokenSymlinks(options, result);
+
+  const cacheFilesAfter = await getAllCacheFiles();
+  result.totalCacheFilesAfter = cacheFilesAfter.length;
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Adds a new `cleanup` command that removes stale configurations from ccmcp's cache by checking if referenced files and directories still exist.

## Changes

### New Files
- `src/cleanup.ts` - Core cleanup logic with support for dry-run, interactive prompts, and verbose output
- `src/__tests__/cleanup.test.ts` - Comprehensive test suite (8 tests)

### Modified Files
- `src/index.ts` - Added CLI argument parsing and cleanup command integration
- `src/__tests__/cli-ux.test.ts` - Updated tests to avoid conflicts with new `--verbose` flag

## Features

✅ Removes cache entries for non-existent project directories  
✅ Cleans up references to deleted MCP server config files  
✅ Detects and removes broken symlinks in config directory  
✅ Supports `--dry-run` flag to preview changes without making modifications  
✅ Supports `--yes` flag for non-interactive automation  
✅ Supports `--verbose` flag for detailed output  
✅ Interactive prompts for user confirmation  
✅ Detailed cleanup statistics reporting  
✅ Preserves valid cache entries and configurations

## Usage

```bash
# Interactive cleanup with prompts
ccmcp cleanup

# Non-interactive cleanup
ccmcp cleanup --yes

# Dry run to preview what would be cleaned
ccmcp cleanup --dry-run

# Verbose output showing details
ccmcp cleanup --verbose
```

## Testing

All tests pass:
- 8 new cleanup tests covering core functionality
- Existing tests updated and passing
- Manual end-to-end testing completed

## Example Output

```
Starting cleanup...
Config directory: /Users/george/.claude/mcp-configs
Cache directory: /Users/george/.cache/ccmcp
Current cache files: 3

Found 1 stale cache entry:
  - /Users/george/old-project (doesn't exist)

Remove these cache entries? [Y/n]

Cleanup Summary:
  Stale cache entries removed: 1
  Invalid server references removed: 0
  Broken symlinks removed: 0
  Cache files: 3 → 2
```

Closes #52