### PR TITLE
fix: isolate cache directories in parallel test execution

### DIFF
--- a/src/__tests__/cleanup.test.ts
+++ b/src/__tests__/cleanup.test.ts
@@ -7,8 +7,16 @@ import { clearCache, getCacheDir, saveSelections } from "../selection-cache.js";
 
 describe.sequential("cleanupCache", () => {
   let testConfigDir: string;
+  let originalCacheHome: string | undefined;
 
   beforeEach(async () => {
+    // Isolate cache directory for this test file
+    originalCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = join(
+      tmpdir(),
+      `ccmcp-cache-cleanup-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+    );
+
     await clearCache();
     testConfigDir = join(tmpdir(), `ccmcp-cleanup-test-${Date.now()}`);
     await mkdir(testConfigDir, { recursive: true });
@@ -19,6 +27,12 @@ describe.sequential("cleanupCache", () => {
 
   afterEach(async () => {
     await clearCache();
+    // Restore original cache home
+    if (originalCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalCacheHome;
+    }
   });
 
   test("removes stale cache entries for non-existent projects", async () => {

--- a/src/__tests__/selection-cache.test.ts
+++ b/src/__tests__/selection-cache.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   clearCache,
   getCacheDir,
@@ -57,6 +57,16 @@ describe("getProjectDir", () => {
 describe("loadSelections and saveSelections", () => {
   const testProjectDir = join(tmpdir(), "ccmcp-test-project");
   const testConfigDir = join(tmpdir(), "ccmcp-test-config");
+  let originalCacheHome: string | undefined;
+
+  beforeEach(async () => {
+    // Isolate cache directory for this test file
+    originalCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = join(
+      tmpdir(),
+      `ccmcp-cache-selection-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+    );
+  });
 
   afterEach(async () => {
     // Clean up any cache files created during tests
@@ -64,6 +74,12 @@ describe("loadSelections and saveSelections", () => {
       await clearCache();
     } catch {
       // Ignore cleanup errors
+    }
+    // Restore original cache home
+    if (originalCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalCacheHome;
     }
   });
 
@@ -143,6 +159,26 @@ describe("loadSelections and saveSelections", () => {
 });
 
 describe("clearCache", () => {
+  let originalCacheHome: string | undefined;
+
+  beforeEach(async () => {
+    // Isolate cache directory for this test file
+    originalCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = join(
+      tmpdir(),
+      `ccmcp-cache-clear-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+    );
+  });
+
+  afterEach(async () => {
+    // Restore original cache home
+    if (originalCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalCacheHome;
+    }
+  });
+
   test("removes all cache files", async () => {
     await saveSelections("/project1", "/config1", ["config1"]);
     await saveSelections("/project2", "/config2", ["config2"]);


### PR DESCRIPTION
## Summary

- Fixes test cache interference when tests run in parallel
- Each test file now uses its own isolated cache directory by overriding `XDG_CACHE_HOME` with a unique temporary path
- Applied to `cleanup.test.ts`, `selection-cache.test.ts` test suites

## Test plan

- [x] Run tests with `pnpm test` to verify all tests pass
- [x] Verify tests can run in parallel without cache conflicts
- [x] Confirm cache isolation doesn't break existing test functionality