### PR TITLE
Fix CLI flag collisions and add ephemeral mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@
 
 - Always use the **github-project-manager** agent when working with `gh project` commands
 
+## CLI Flag Management
+
+- **ALWAYS** check for collisions with Claude Code flags before adding new flags
+- Run `claude -h` to see current Claude Code flags
+- This project allows passthrough args to Claude Code, so flag collisions break functionality
+
 ## Important Scripts
 
 ### Development & Testing

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ever have multiple MCP server configs but only want to use specific ones for dif
 - 🌳 **Git worktree aware** - selections are shared across worktrees of the same repository
 - 🚀 **Launches Claude Code** with only your chosen configs
 - 🧹 **Cleanup** stale cache entries and broken symlinks
+- 👻 **Ephemeral mode** for one-off selections without saving
 - ⚙️ **Configurable** via CLI options or environment variables
 
 ## Installation
@@ -55,14 +56,17 @@ CCMCP_CONFIG_DIR=/path/to/configs ccmcp
 ccmcp --resume
 
 # Cache management
-ccmcp --ignore-cache          # Skip loading previous selections
+ccmcp -i                      # Skip loading previous selections (short flag)
+ccmcp --ignore-cache          # Skip loading previous selections (long flag)
+ccmcp -n                      # Don't save selections (ephemeral mode)
+ccmcp --no-save               # Don't save selections (ephemeral mode)
+ccmcp -in                     # Combine: fresh start + no saving
 ccmcp --clear-cache           # Clear all cached selections
 
 # Cleanup stale cache entries and broken symlinks
 ccmcp cleanup                 # Interactive cleanup with prompts
 ccmcp cleanup --dry-run       # Preview what would be cleaned
 ccmcp cleanup --yes           # Skip prompts, automatically proceed
-ccmcp cleanup --verbose       # Show detailed cleanup information
 ```
 
 **Cleanup notes:**

--- a/src/__tests__/cleanup.test.ts
+++ b/src/__tests__/cleanup.test.ts
@@ -56,7 +56,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.staleCacheEntries).toBe(1);
@@ -81,7 +80,6 @@ describe.sequential("cleanupCache", () => {
         configDir: testConfigDir,
         dryRun: true,
         yes: true,
-        verbose: false,
       })
     ).totalCacheFilesBefore;
 
@@ -91,7 +89,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.totalCacheFilesAfter).toBeLessThanOrEqual(cacheCountBefore);
@@ -108,7 +105,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.brokenSymlinks).toBe(1);
@@ -125,7 +121,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.brokenSymlinks).toBe(0);
@@ -136,7 +131,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.brokenSymlinks).toBe(0);
@@ -150,7 +144,6 @@ describe.sequential("cleanupCache", () => {
       configDir: nonExistentDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.brokenSymlinks).toBe(0);
@@ -170,7 +163,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.totalCacheFilesAfter).toBeGreaterThanOrEqual(1);
@@ -197,7 +189,6 @@ describe.sequential("cleanupCache", () => {
       configDir: testConfigDir,
       dryRun: false,
       yes: true,
-      verbose: false,
     });
 
     expect(result.staleCacheEntries).toBe(1);

--- a/src/__tests__/cli-ux.test.ts
+++ b/src/__tests__/cli-ux.test.ts
@@ -141,16 +141,49 @@ describe("CLI User Experience", () => {
       }
     });
 
-    it("should parse short config-dir flag correctly", async () => {
+    it("should parse short ignore-cache flag correctly", async () => {
       const originalArgv = process.argv;
 
       try {
-        process.argv = ["node", "ccmcp", "-c", "/test/path"];
+        process.argv = ["node", "ccmcp", "-i"];
 
         const { parseCliArgs } = await import("../index.js");
         const result = parseCliArgs();
 
-        expect(result.values["config-dir"]).toBe("/test/path");
+        expect(result.values["ignore-cache"]).toBe(true);
+        expect(result.positionals).toHaveLength(0);
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+
+    it("should parse short no-save flag correctly", async () => {
+      const originalArgv = process.argv;
+
+      try {
+        process.argv = ["node", "ccmcp", "-n"];
+
+        const { parseCliArgs } = await import("../index.js");
+        const result = parseCliArgs();
+
+        expect(result.values["no-save"]).toBe(true);
+        expect(result.positionals).toHaveLength(0);
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+
+    it("should parse combined short flags correctly", async () => {
+      const originalArgv = process.argv;
+
+      try {
+        process.argv = ["node", "ccmcp", "-in"];
+
+        const { parseCliArgs } = await import("../index.js");
+        const result = parseCliArgs();
+
+        expect(result.values["ignore-cache"]).toBe(true);
+        expect(result.values["no-save"]).toBe(true);
         expect(result.positionals).toHaveLength(0);
       } finally {
         process.argv = originalArgv;
@@ -176,7 +209,14 @@ describe("CLI User Experience", () => {
       const originalArgv = process.argv;
 
       try {
-        process.argv = ["node", "ccmcp", "-c", "/path", "--resume", "--debug"];
+        process.argv = [
+          "node",
+          "ccmcp",
+          "--config-dir",
+          "/path",
+          "--resume",
+          "--debug",
+        ];
 
         const { parseCliArgs } = await import("../index.js");
         const result = parseCliArgs();
@@ -236,7 +276,9 @@ describe("CLI User Experience", () => {
         expect(helpOutput).toContain("Options:");
         expect(helpOutput).toContain("  -h, --help");
         expect(helpOutput).toContain("  -v, --version");
-        expect(helpOutput).toContain("  -c, --config-dir");
+        expect(helpOutput).toContain("  --config-dir");
+        expect(helpOutput).toContain("  -i, --ignore-cache");
+        expect(helpOutput).toContain("  -n, --no-save");
 
         // Should have Environment Variables section
         expect(helpOutput).toContain("Environment Variables:");


### PR DESCRIPTION
## Summary

Resolves critical flag collisions with Claude Code's passthrough functionality and adds new ephemeral selection mode.

## Changes

### Flag Collisions Fixed
- **Remove `-c` short flag** for `--config-dir` (conflicted with Claude's `--continue`)
- **Remove `--verbose` flag** from cleanup mode (conflicted with Claude's `--verbose`)

Users can now properly pass these flags through to Claude Code without interception.

### New Features
- **Add `-i` short flag** for `--ignore-cache` (convenience shorthand)
- **Add `-n` / `--no-save` flag** for ephemeral mode (don't persist selections)
- **Support combined short flags** like `-in` for one-off server selection without polluting project cache

### Documentation
- Updated CLI help text with new flag descriptions
- Updated README with usage examples including `-in` combo
- Added project memory requirement to check for Claude Code flag collisions before adding new flags

## Testing

- ✅ All 150 tests passing
- ✅ Build successful (lint, type-check, compile)
- ✅ New tests for `-i`, `-n`, and `-in` combined flags
- ✅ Updated cleanup tests to remove verbose parameter

## Breaking Changes

⚠️ **Note:** Removing `-c` and `--verbose` are technically breaking changes, but they were already broken due to flag collisions. Users affected by this can:
- Use `--config-dir` instead of `-c` (or set `CCMCP_CONFIG_DIR` env var)
- Cleanup verbose output has been streamlined (no flag needed)

## Example Usage

```bash
# Ephemeral one-off selection (your original use case)
ccmcp -in

# Continue Claude session (now works!)
ccmcp -c

# Claude verbose mode (now works!)
ccmcp --verbose
```