### PR TITLE
build(node): update minimum Node.js version to 22.18.0 or 24.2.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.18.x, 24.2.x, 25.x]
 
     steps:
       - name: Checkout code
@@ -85,5 +85,8 @@ jobs:
 
       - name: Test CLI functionality
         run: |
-          node dist/index.js --help
-          node dist/index.js --version
+          HELP_OUTPUT=$(node dist/index.js --help)
+          echo "$HELP_OUTPUT" | grep -q "Usage:" || (echo "ERROR: --help produced no output" && exit 1)
+
+          VERSION_OUTPUT=$(node dist/index.js --version)
+          [ -n "$VERSION_OUTPUT" ] || (echo "ERROR: --version produced no output" && exit 1)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,19 +6,23 @@ This document contains information for developers working on ccmcp.
 
 ### Prerequisites
 
-- Node.js 18+
-- pnpm 10.17.0+ (package manager)
-- Claude Code installed and available in PATH
-- Terminal with TTY support for TUI testing
+* Node.js 22.18+ or 24.2+ (not 23.x or 24.0-24.1)
+* pnpm 10.17.0+ (package manager)
+* Claude Code installed and available in PATH
+* Terminal with TTY support for TUI testing
 
 ### Setup
 
 1. Clone the repository
+
 2. Install dependencies:
+
    ```bash
    pnpm install
    ```
+
 3. Test the CLI during development:
+
    ```bash
    pnpm run dev
    ```
@@ -106,36 +110,36 @@ scripts/
 
 ### Key Components
 
-- **CLI Entry (`index.ts`)**: Handles argument parsing, help/version display, config directory resolution, and orchestrates the main flow including cleanup command
-- **MCP Scanner (`mcp-scanner.ts`)**: Discovers and validates MCP configuration files using comprehensive schema validation
-- **Schema Validation (`schemas/mcp-config.ts`)**: Zod-based schemas for validating MCP config structure with detailed error messages, supporting both modern and legacy formats (type field optional, defaults to "stdio")
-- **Selection Cache (`selection-cache.ts`)**: Manages persistent caching of config selections per project directory, with support for XDG cache directories on Linux/macOS and AppData on Windows
-- **Cleanup (`cleanup.ts`)**: Provides cleanup functionality to remove stale cache entries, invalid server references, and broken symlinks with dry-run and interactive modes
-- **Test Suite (`__tests__/`)**: Comprehensive unit tests for schema validation, cache management, cleanup operations, and utility functions using Vitest
-- **Console Selector (`console-selector.ts`)**: Manages config selection with TTY detection and TUI/readline fallback
-- **TUI Components (`tui/`)**: React/Ink-based terminal user interface with modern navigation and visual feedback
-- **Claude Launcher (`claude-launcher.ts`)**: Manages Claude Code process spawning with selected configs
+* __CLI Entry (`index.ts`)__: Handles argument parsing, help/version display, config directory resolution, and orchestrates the main flow including cleanup command
+* __MCP Scanner (`mcp-scanner.ts`)__: Discovers and validates MCP configuration files using comprehensive schema validation
+* __Schema Validation (`schemas/mcp-config.ts`)__: Zod-based schemas for validating MCP config structure with detailed error messages, supporting both modern and legacy formats (type field optional, defaults to "stdio")
+* __Selection Cache (`selection-cache.ts`)__: Manages persistent caching of config selections per project directory, with support for XDG cache directories on Linux/macOS and AppData on Windows
+* __Cleanup (`cleanup.ts`)__: Provides cleanup functionality to remove stale cache entries, invalid server references, and broken symlinks with dry-run and interactive modes
+* __Test Suite (`__tests__/`)__: Comprehensive unit tests for schema validation, cache management, cleanup operations, and utility functions using Vitest
+* __Console Selector (`console-selector.ts`)__: Manages config selection with TTY detection and TUI/readline fallback
+* __TUI Components (`tui/`)__: React/Ink-based terminal user interface with modern navigation and visual feedback
+* __Claude Launcher (`claude-launcher.ts`)__: Manages Claude Code process spawning with selected configs
 
 ## Build Process
 
 The build process uses modern TypeScript tooling:
 
-1. **Linting**: Uses Biome for code quality and style checking
-2. **Type Checking**: Validates TypeScript types without emitting files
-3. **Compilation**: Uses tsup to bundle and transpile TypeScript to JavaScript in `dist/` directory
-4. **Testing**: Unit tests using Vitest test framework
-5. **CLI Testing**: CLI functionality testing with `--help` and `--version`
+1. __Linting__: Uses Biome for code quality and style checking
+2. __Type Checking__: Validates TypeScript types without emitting files
+3. __Compilation__: Uses tsup to bundle and transpile TypeScript to JavaScript in `dist/` directory
+4. __Testing__: Unit tests using Vitest test framework
+5. __CLI Testing__: CLI functionality testing with `--help` and `--version`
 
 ## CI/CD Pipeline
 
 GitHub Actions workflow (`.github/workflows/ci.yml`) runs on:
 
-- Push to `main` branch
-- Pull requests targeting `main`
+* Push to `main` branch
+* Pull requests targeting `main`
 
 ### CI Jobs
 
-**Quality Checks** (runs on Node.js 18.x, 20.x, 22.x):
+__Quality Checks__ (runs on Node.js 22.18.x, 24.2.x, 25.x):
 
 1. Checkout code and setup pnpm 10.17.0
 2. Install dependencies with frozen lockfile
@@ -148,83 +152,83 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on:
 
 ### Caching Strategy
 
-- Uses pnpm store caching with unique keys per Node.js version
-- Cache keys include `pnpm-lock.yaml` hash for dependency changes
+* Uses pnpm store caching with unique keys per Node.js version
+* Cache keys include `pnpm-lock.yaml` hash for dependency changes
 
 ### Concurrency
 
-- Cancels in-progress workflows when new commits are pushed to the same PR or branch
+* Cancels in-progress workflows when new commits are pushed to the same PR or branch
 
 ## Release Process
 
 The project uses automated release management with GitHub Actions for publishing:
 
-1. **Version Bumping**: Uses `scripts/release.js` to bump version in `package.json`
-2. **Release Notes**: Generates changelog from git commits using `scripts/generate-release-notes.js`
-3. **Git Tagging**: Creates version tags (e.g., `v1.0.0`) and pushes to GitHub
-4. **CI Publishing**: GitHub Actions automatically builds and publishes to npm via OIDC
+1. __Version Bumping__: Uses `scripts/release.js` to bump version in `package.json`
+2. __Release Notes__: Generates changelog from git commits using `scripts/generate-release-notes.js`
+3. __Git Tagging__: Creates version tags (e.g., `v1.0.0`) and pushes to GitHub
+4. __CI Publishing__: GitHub Actions automatically builds and publishes to npm via OIDC
 
 ### Release Commands
 
-- `pnpm run release:patch` - Bug fixes and minor changes (1.0.0 → 1.0.1)
-- `pnpm run release:minor` - New features, backward compatible (1.0.0 → 1.1.0)
-- `pnpm run release:major` - Breaking changes (1.0.0 → 2.0.0)
+* `pnpm run release:patch` - Bug fixes and minor changes (1.0.0 → 1.0.1)
+* `pnpm run release:minor` - New features, backward compatible (1.0.0 → 1.1.0)
+* `pnpm run release:major` - Breaking changes (1.0.0 → 2.0.0)
 
 ### Publishing Workflow
 
-The project uses **npm Trusted Publishers (OIDC)** for secure, token-free publishing:
+The project uses __npm Trusted Publishers (OIDC)__ for secure, token-free publishing:
 
-- Release scripts run locally and push a git tag
-- GitHub Actions workflow (`.github/workflows/publish.yml`) triggers on tag push
-- Workflow builds project and publishes to npm using OIDC authentication
-- No npm tokens required anywhere
+* Release scripts run locally and push a git tag
+* GitHub Actions workflow (`.github/workflows/publish.yml`) triggers on tag push
+* Workflow builds project and publishes to npm using OIDC authentication
+* No npm tokens required anywhere
 
 ### Initial Setup (One-Time)
 
 To enable automated publishing, configure Trusted Publishers on npmjs.com:
 
-1. Go to https://www.npmjs.com/package/@gsong/ccmcp/access
+1. Go to <https://www.npmjs.com/package/@gsong/ccmcp/access>
 2. Click "Publishing access" → "Add a publisher"
 3. Select "GitHub Actions"
 4. Configure:
-   - Repository: `gsong/ccmcp`
-   - Workflow: `publish.yml`
-   - Environment: (leave blank)
+   * Repository: `gsong/ccmcp`
+   * Workflow: `publish.yml`
+   * Environment: (leave blank)
 
 ## Tools and Configuration
 
 ### Code Quality Tools
 
-- **Biome**: Linting and formatting for TypeScript/JavaScript
-- **Prettier**: Formatting for markdown, JSON, YAML files
-- **TypeScript**: Type checking
-- **Vitest**: Modern unit testing framework
-- **tsup**: TypeScript bundler for building the project
+* __Biome__: Linting and formatting for TypeScript/JavaScript
+* __Prettier__: Formatting for markdown, JSON, YAML files
+* __TypeScript__: Type checking
+* __Vitest__: Modern unit testing framework
+* __tsup__: TypeScript bundler for building the project
 
 ### Libraries and Frameworks
 
-- **Zod**: Runtime schema validation with TypeScript integration
-- **React + Ink**: Terminal user interface framework
-- **shell-quote**: Command-line argument parsing for safe shell command construction
-- **npm-run-all2**: Utility for running multiple npm scripts sequentially or in parallel
+* __Zod__: Runtime schema validation with TypeScript integration
+* __React + Ink__: Terminal user interface framework
+* __shell-quote__: Command-line argument parsing for safe shell command construction
+* __npm-run-all2__: Utility for running multiple npm scripts sequentially or in parallel
 
 ### Configuration Files
 
-- `biome.json` - Biome linter and formatter settings
-- `tsconfig.json` - TypeScript compiler configuration
-- `tsup.config.ts` - tsup bundler configuration
-- `vitest.config.ts` - Vitest test framework configuration
-- `.prettierignore` - Files excluded from Prettier formatting
-- `.gitignore` - Git ignore patterns including build artifacts
+* `biome.json` - Biome linter and formatter settings
+* `tsconfig.json` - TypeScript compiler configuration
+* `tsup.config.ts` - tsup bundler configuration
+* `vitest.config.ts` - Vitest test framework configuration
+* `.prettierignore` - Files excluded from Prettier formatting
+* `.gitignore` - Git ignore patterns including build artifacts
 
 ## Contributing
 
 ### Code Style
 
-- Follow existing TypeScript conventions
-- Use Biome for code formatting
-- Ensure type safety (no `any` types without justification)
-- Write descriptive commit messages following conventional commits
+* Follow existing TypeScript conventions
+* Use Biome for code formatting
+* Ensure type safety (no `any` types without justification)
+* Write descriptive commit messages following conventional commits
 
 ### Testing
 
@@ -234,28 +238,28 @@ The project includes both unit tests and manual CLI testing. Before contributing
 
 1. Run the test suite: `pnpm test`
 2. Tests cover:
-   - Schema validation for valid STDIO, HTTP, and SSE server configurations
-   - Invalid configurations with proper error messages
-   - Edge cases and malformed JSON
-   - Utility functions for error formatting
-   - Selection cache management (load, save, clear)
-   - Cleanup operations (stale entries, invalid references, broken symlinks)
+   * Schema validation for valid STDIO, HTTP, and SSE server configurations
+   * Invalid configurations with proper error messages
+   * Edge cases and malformed JSON
+   * Utility functions for error formatting
+   * Selection cache management (load, save, clear)
+   * Cleanup operations (stale entries, invalid references, broken symlinks)
 
 #### Manual Testing
 
 1. Ensure your changes don't break `--help` and `--version` commands
 2. Test MCP config discovery and selection manually with different directory options:
-   - Default directory (`~/.claude/mcp-configs/`)
-   - Custom directory via `--config-dir`
-   - Custom directory via `CCMCP_CONFIG_DIR` environment variable
+   * Default directory (`~/.claude/mcp-configs/`)
+   * Custom directory via `--config-dir`
+   * Custom directory via `CCMCP_CONFIG_DIR` environment variable
 3. Test selection caching:
-   - Verify selections are remembered per project
-   - Test `--ignore-cache` flag
-   - Test `--clear-cache` flag
+   * Verify selections are remembered per project
+   * Test `--ignore-cache` flag
+   * Test `--clear-cache` flag
 4. Test cleanup command:
-   - Run `cleanup --dry-run` to preview changes
-   - Test with `--yes` and `--verbose` flags
-   - Verify removal of stale entries, invalid references, and broken symlinks
+   * Run `cleanup --dry-run` to preview changes
+   * Test with `--yes` and `--verbose` flags
+   * Verify removal of stale entries, invalid references, and broken symlinks
 5. Verify Claude Code launching with various config combinations
 6. Test error handling for non-existent config directories and invalid configs
 7. Test TUI functionality in TTY environments and readline fallback in non-TTY contexts

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^22.18.0 || >=24.2.0"
   },
   "type": "module",
   "scripts": {

--- a/specs/implementation.md
+++ b/specs/implementation.md
@@ -6,10 +6,10 @@ This document provides comprehensive technical implementation details including 
 
 ### Runtime Environment
 
-- **Node.js**: Minimum version 18.0.0
-- **Platform Support**: Cross-platform (macOS, Linux, Windows)
-- **Module System**: ES Modules (ESM) with `.js` extensions
-- **Package Manager**: pnpm (recommended), npm compatible
+* __Node.js__: Version 22.18.0+ or 24.2.0+ (excludes 23.x and 24.0-24.1)
+* __Platform Support__: Cross-platform (macOS, Linux, Windows)
+* __Module System__: ES Modules (ESM) with `.js` extensions
+* __Package Manager__: pnpm (recommended), npm compatible
 
 ### Core Dependencies
 
@@ -24,12 +24,12 @@ This document provides comprehensive technical implementation details including 
 }
 ```
 
-**Dependency Justification**:
+__Dependency Justification__:
 
-- **React**: Component-based architecture for TUI
-- **Ink**: Terminal interface rendering engine
-- **Zod**: Runtime schema validation with TypeScript integration
-- **@types/react**: TypeScript definitions for React
+* __React__: Component-based architecture for TUI
+* __Ink__: Terminal interface rendering engine
+* __Zod__: Runtime schema validation with TypeScript integration
+* __@types/react__: TypeScript definitions for React
 
 #### Development Dependencies
 
@@ -44,14 +44,14 @@ This document provides comprehensive technical implementation details including 
 }
 ```
 
-**Dependency Justification**:
+__Dependency Justification__:
 
-- **TypeScript**: Type safety and compile-time error checking
-- **tsx**: Development execution of TypeScript files
-- **Biome**: Fast linting and formatting
-- **@types/node**: Node.js type definitions
-- **npm-run-all2**: Script orchestration and parallelization
-- **Prettier**: Code formatting for non-JavaScript files
+* __TypeScript__: Type safety and compile-time error checking
+* __tsx__: Development execution of TypeScript files
+* __Biome__: Fast linting and formatting
+* __@types/node__: Node.js type definitions
+* __npm-run-all2__: Script orchestration and parallelization
+* __Prettier__: Code formatting for non-JavaScript files
 
 ### Built-in Node.js Modules
 
@@ -104,17 +104,17 @@ import { main } from "./main.js";
 
 #### Core Modules
 
-- **Scanner**: Configuration file discovery and validation
-- **Selector**: User interface and interaction handling
-- **Launcher**: Process spawning and lifecycle management
-- **Utils**: Shared utilities and error formatting
+* __Scanner__: Configuration file discovery and validation
+* __Selector__: User interface and interaction handling
+* __Launcher__: Process spawning and lifecycle management
+* __Utils__: Shared utilities and error formatting
 
 #### React Components (`src/tui/`)
 
-- **ConfigSelector**: Main selection interface
-- **ConfigPreview**: File content preview panel
-- **ErrorDisplay**: Validation error display
-- **index.ts**: Component exports
+* __ConfigSelector__: Main selection interface
+* __ConfigPreview__: File content preview panel
+* __ErrorDisplay__: Validation error display
+* __index.ts__: Component exports
 
 ## Build System Configuration
 
@@ -142,13 +142,13 @@ import { main } from "./main.js";
 }
 ```
 
-**Key Configuration Decisions**:
+__Key Configuration Decisions__:
 
-- **ES2022 Target**: Modern JavaScript features with Node 18+ support
-- **Node16 Module Resolution**: Proper ESM handling with file extensions
-- **Strict Mode**: Maximum type safety
-- **JSX Support**: React component compilation
-- **Source Maps**: Development debugging support
+* __ES2022 Target__: Modern JavaScript features with Node 18+ support
+* __Node16 Module Resolution__: Proper ESM handling with file extensions
+* __Strict Mode__: Maximum type safety
+* __JSX Support__: React component compilation
+* __Source Maps__: Development debugging support
 
 ### Biome Configuration (`biome.json`)
 
@@ -189,7 +189,7 @@ import { main } from "./main.js";
   },
   "type": "module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^22.18.0 || >=24.2.0"
   }
 }
 ```
@@ -268,9 +268,9 @@ node --test src/__tests__/utils.test.ts
 
 ### Unit Testing Framework
 
-- **Built-in Node.js Test Runner**: No external dependencies
-- **Assert Module**: Node.js built-in assertions
-- **Test Discovery**: `src/**/*.test.ts` pattern
+* __Built-in Node.js Test Runner__: No external dependencies
+* __Assert Module__: Node.js built-in assertions
+* __Test Discovery__: `src/**/*.test.ts` pattern
 
 ### Test Structure Example
 
@@ -313,17 +313,17 @@ describe("MCP Configuration Schema", () => {
 
 ### Test Categories
 
-1. **Schema Validation Tests**: Comprehensive validation rule testing
-2. **Utility Function Tests**: Error formatting and helper functions
-3. **Integration Tests**: End-to-end workflow testing
-4. **CLI Argument Tests**: Argument parsing validation
+1. __Schema Validation Tests__: Comprehensive validation rule testing
+2. __Utility Function Tests__: Error formatting and helper functions
+3. __Integration Tests__: End-to-end workflow testing
+4. __CLI Argument Tests__: Argument parsing validation
 
 ### Test Coverage Goals
 
-- **Schema Validation**: 100% of validation rules tested
-- **Error Handling**: All error paths covered
-- **Utility Functions**: Complete function coverage
-- **Edge Cases**: Boundary conditions and error states
+* __Schema Validation__: 100% of validation rules tested
+* __Error Handling__: All error paths covered
+* __Utility Functions__: Complete function coverage
+* __Edge Cases__: Boundary conditions and error states
 
 ## Error Handling Strategy
 
@@ -363,10 +363,10 @@ class UserError extends Error {
 
 ### Error Recovery Patterns
 
-- **Graceful Degradation**: Continue with partial success
-- **User Guidance**: Provide actionable error messages
-- **Fallback Options**: Alternative execution paths
-- **Resource Cleanup**: Proper cleanup on failures
+* __Graceful Degradation__: Continue with partial success
+* __User Guidance__: Provide actionable error messages
+* __Fallback Options__: Alternative execution paths
+* __Resource Cleanup__: Proper cleanup on failures
 
 ## Performance Optimizations
 
@@ -388,15 +388,15 @@ const configResults = await Promise.all(
 
 ### Memory Management
 
-- **Streaming**: Large files processed incrementally
-- **Cleanup**: Explicit resource disposal
-- **Minimal Footprint**: Only load necessary data into memory
+* __Streaming__: Large files processed incrementally
+* __Cleanup__: Explicit resource disposal
+* __Minimal Footprint__: Only load necessary data into memory
 
 ### Startup Performance
 
-- **Lazy Loading**: Components loaded on demand
-- **Parallel Operations**: File scanning and validation
-- **Minimal Dependencies**: Small production bundle
+* __Lazy Loading__: Components loaded on demand
+* __Parallel Operations__: File scanning and validation
+* __Minimal Dependencies__: Small production bundle
 
 ## Security Considerations
 
@@ -422,18 +422,18 @@ function validateCommand(command: string): void {
 
 ### Process Security
 
-- **Minimal Privileges**: Child processes spawn with limited access
-- **Environment Isolation**: Controlled environment variable passing
-- **Signal Handling**: Proper cleanup on termination
+* __Minimal Privileges__: Child processes spawn with limited access
+* __Environment Isolation__: Controlled environment variable passing
+* __Signal Handling__: Proper cleanup on termination
 
 ## Release Management
 
 ### Versioning Strategy
 
-- **Semantic Versioning**: MAJOR.MINOR.PATCH format
-- **Patch Releases**: Bug fixes and minor improvements
-- **Minor Releases**: New features with backward compatibility
-- **Major Releases**: Breaking changes
+* __Semantic Versioning__: MAJOR.MINOR.PATCH format
+* __Patch Releases__: Bug fixes and minor improvements
+* __Minor Releases__: New features with backward compatibility
+* __Major Releases__: Breaking changes
 
 ### Release Process
 
@@ -450,20 +450,20 @@ pnpm run release:major
 
 ### Release Checklist
 
-1. **Tests Pass**: All unit tests successful
-2. **Build Success**: Clean compilation without errors
-3. **Linting Clean**: No linting violations
-4. **Type Check**: TypeScript validation passes
-5. **Manual Testing**: CLI functionality verified
-6. **Documentation Updated**: CHANGELOG.md updated
+1. __Tests Pass__: All unit tests successful
+2. __Build Success__: Clean compilation without errors
+3. __Linting Clean__: No linting violations
+4. __Type Check__: TypeScript validation passes
+5. __Manual Testing__: CLI functionality verified
+6. __Documentation Updated__: CHANGELOG.md updated
 
 ## Deployment and Distribution
 
 ### NPM Package Publishing
 
-- **Registry**: npmjs.com public registry
-- **Package Scope**: Scoped package name `@gsong/ccmcp`
-- **Binary Installation**: Global installation via `npm install -g @gsong/ccmcp`
+* __Registry__: npmjs.com public registry
+* __Package Scope__: Scoped package name `@gsong/ccmcp`
+* __Binary Installation__: Global installation via `npm install -g @gsong/ccmcp`
 
 ### Package Contents
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   sourcemap: false,
   clean: true,
   external: ["ink", "react", "zod", "shell-quote"],
-  target: "node18",
+  target: "node22.18",
   shims: false,
   bundle: true,
 });


### PR DESCRIPTION
## Summary

Updates Node.js engine requirements from 18+ to `^22.18.0 || >=24.2.0` to ensure proper support for `import.meta.main` entry point detection.

## Why This Change Is Necessary

Claude Code MCP Selector uses `import.meta.main` to detect if the module is being run as the main entry point. However, this feature is only available in:
- Node.js ^22.18.0
- Node.js 24.2.0+ (not available in 23.x or 24.0-24.1.x)

Without proper `import.meta.main` support, the CLI exits successfully (code 0) but produces no output - the entire application silently fails. This creates a confusing user experience where the command appears to work but does nothing.

## Changes

- Update package.json engines constraint from `^18.0.0` to `^22.18.0 || >=24.2.0`
- Update tsup build target from Node 18 to Node 22.18
- Update CI matrix to test against 22.18.x, 24.2.x, 25.x
- Modify existing integration tests to verify stdout content (catches silent failures where CLI exits successfully but produces no output)
- Modify CI workflow to verify stdout content
- Update documentation in DEVELOPMENT.md and specs/implementation.md

## Breaking Change

Node.js 18.x-22.17.x and 23.x-24.1.x are no longer supported. Requires Node.js 22.18.0+ from Node.js 22 LTS or Node.js 24.2.0+.

## Test Plan

- [x] All existing tests pass
- [x] Modified integration tests verify CLI produces output
- [x] CI workflow validates output content