### PR TITLE
refactor: extract shared constants

### DIFF
--- a/src/__tests__/selection-cache.test.ts
+++ b/src/__tests__/selection-cache.test.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { CACHE_FILE_EXTENSION, CACHE_FILE_PREFIX } from "../constants.js";
 import {
   clearCache,
   getCacheDir,
@@ -173,7 +174,10 @@ describe("loadSelections and saveSelections", () => {
 
     // Manually create a corrupted cache file
     const hash = "abc123";
-    const filePath = join(cacheDir, `selections-${hash}.json`);
+    const filePath = join(
+      cacheDir,
+      `${CACHE_FILE_PREFIX}${hash}${CACHE_FILE_EXTENSION}`,
+    );
     await writeFile(filePath, "corrupted json", "utf-8");
 
     const loaded = await loadSelections(testProjectDir, testConfigDir);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 import {
+  CACHE_FILE_EXTENSION,
   CACHE_FILE_PREFIX,
   CACHE_VERSION,
   CONFIG_FILE_EXTENSION,
@@ -65,7 +66,7 @@ async function getAllCacheFiles(): Promise<string[]> {
       .filter(
         (file) =>
           file.startsWith(CACHE_FILE_PREFIX) &&
-          file.endsWith(CONFIG_FILE_EXTENSION),
+          file.endsWith(CACHE_FILE_EXTENSION),
       )
       .map((file) => join(cacheDir, file));
   } catch {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -8,6 +8,11 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  CACHE_FILE_PREFIX,
+  CACHE_VERSION,
+  CONFIG_FILE_EXTENSION,
+} from "./constants.js";
 import { getCacheDir, type SelectionCache } from "./selection-cache.js";
 
 export interface CleanupOptions {
@@ -58,7 +63,9 @@ async function getAllCacheFiles(): Promise<string[]> {
     const files = await readdir(cacheDir);
     return files
       .filter(
-        (file) => file.startsWith("selections-") && file.endsWith(".json"),
+        (file) =>
+          file.startsWith(CACHE_FILE_PREFIX) &&
+          file.endsWith(CONFIG_FILE_EXTENSION),
       )
       .map((file) => join(cacheDir, file));
   } catch {
@@ -71,7 +78,7 @@ async function loadCacheFile(filePath: string): Promise<SelectionCache | null> {
     const content = await readFile(filePath, "utf-8");
     const cache: SelectionCache = JSON.parse(content);
 
-    if (cache.version !== 1) {
+    if (cache.version !== CACHE_VERSION) {
       return null;
     }
 
@@ -178,7 +185,10 @@ async function cleanupInvalidServerReferences(
 
     const invalidConfigs: string[] = [];
     for (const configName of cache.selectedConfigs) {
-      const configPath = join(cache.configDir, `${configName}.json`);
+      const configPath = join(
+        cache.configDir,
+        `${configName}${CONFIG_FILE_EXTENSION}`,
+      );
       const exists = await fileExists(configPath);
       if (!exists) {
         invalidConfigs.push(configName);
@@ -269,7 +279,9 @@ async function cleanupBrokenSymlinks(
 ): Promise<void> {
   try {
     const files = await readdir(options.configDir);
-    const jsonFiles = files.filter((file) => file.endsWith(".json"));
+    const jsonFiles = files.filter((file) =>
+      file.endsWith(CONFIG_FILE_EXTENSION),
+    );
     const brokenLinks: string[] = [];
 
     for (const file of jsonFiles) {

--- a/src/console-selector.ts
+++ b/src/console-selector.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline";
 import { render } from "ink";
 import React from "react";
+import { DEFAULT_CONFIG_DIR_LABEL } from "./constants.js";
 import type { McpConfig } from "./mcp-scanner.js";
 import { ConfigSelector } from "./tui/index.js";
 import { getPackageVersion } from "./utils.js";
@@ -30,7 +31,7 @@ export async function selectConfigs(
 ): Promise<McpConfig[]> {
   if (configs.length === 0) {
     console.log(
-      `No MCP configs found in ${configDir || "~/.claude/mcp-configs/"}`,
+      `No MCP configs found in ${configDir || DEFAULT_CONFIG_DIR_LABEL}`,
     );
     return [];
   }

--- a/src/console-selector.ts
+++ b/src/console-selector.ts
@@ -1,7 +1,7 @@
 import { createInterface } from "node:readline";
 import { render } from "ink";
 import React from "react";
-import { DEFAULT_CONFIG_DIR_LABEL } from "./constants.js";
+import { DEFAULT_CONFIG_DIR_DISPLAY } from "./constants.js";
 import type { McpConfig } from "./mcp-scanner.js";
 import { ConfigSelector } from "./tui/index.js";
 import { getPackageVersion } from "./utils.js";
@@ -31,7 +31,7 @@ export async function selectConfigs(
 ): Promise<McpConfig[]> {
   if (configs.length === 0) {
     console.log(
-      `No MCP configs found in ${configDir || DEFAULT_CONFIG_DIR_LABEL}`,
+      `No MCP configs found in ${configDir || `${DEFAULT_CONFIG_DIR_DISPLAY}/`}`,
     );
     return [];
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,12 @@
+// Cache constants
 export const CACHE_FILE_PREFIX = "selections-";
-export const CONFIG_FILE_EXTENSION = ".json";
+export const CACHE_FILE_EXTENSION = ".json";
 export const CACHE_VERSION = 1 as const;
+
+// Directory & config-file constants
 export const CLAUDE_DIR = ".claude";
 export const MCP_CONFIGS_DIR = "mcp-configs";
+export const CONFIG_FILE_EXTENSION = ".json";
+
+// Derived display strings
 export const DEFAULT_CONFIG_DIR_DISPLAY = `~/${CLAUDE_DIR}/${MCP_CONFIGS_DIR}`;
-export const DEFAULT_CONFIG_DIR_LABEL = `${DEFAULT_CONFIG_DIR_DISPLAY}/`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const CACHE_FILE_PREFIX = "selections-";
+export const CONFIG_FILE_EXTENSION = ".json";
+export const CACHE_VERSION = 1 as const;
+export const CLAUDE_DIR = ".claude";
+export const MCP_CONFIGS_DIR = "mcp-configs";
+export const DEFAULT_CONFIG_DIR_DISPLAY = `~/${CLAUDE_DIR}/${MCP_CONFIGS_DIR}`;
+export const DEFAULT_CONFIG_DIR_LABEL = `${DEFAULT_CONFIG_DIR_DISPLAY}/`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import { parseArgs } from "node:util";
 import { launchClaudeCode } from "./claude-launcher.js";
 import { cleanupCache } from "./cleanup.js";
 import { selectConfigs } from "./console-selector.js";
+import {
+  CLAUDE_DIR,
+  DEFAULT_CONFIG_DIR_DISPLAY,
+  MCP_CONFIGS_DIR,
+} from "./constants.js";
 import type { McpConfig } from "./mcp-scanner.js";
 import { MissingConfigDirectoryError, scanMcpConfigs } from "./mcp-scanner.js";
 import {
@@ -45,7 +50,7 @@ Description:
 Options:
   -h, --help                 Show this help message
   -v, --version              Show version information
-  --config-dir <dir>         Specify MCP config directory (default: ~/.claude/mcp-configs)
+  --config-dir <dir>         Specify MCP config directory (default: ${DEFAULT_CONFIG_DIR_DISPLAY})
   -i, --ignore-cache         Skip loading previously selected configs
   -n, --no-save              Don't save selections (ephemeral mode)
   --clear-cache              Clear all cached selections and exit
@@ -194,7 +199,7 @@ export async function main(): Promise<number> {
   if (values.cleanup) {
     const configDir = values["config-dir"] || process.env.CCMCP_CONFIG_DIR;
     const resolvedConfigDir =
-      configDir || join(homedir(), ".claude", "mcp-configs");
+      configDir || join(homedir(), CLAUDE_DIR, MCP_CONFIGS_DIR);
 
     const result = await cleanupCache({
       configDir: resolvedConfigDir,
@@ -227,7 +232,7 @@ export async function main(): Promise<number> {
     // Determine config directory with precedence: CLI > env > default
     const configDir = values["config-dir"] || process.env.CCMCP_CONFIG_DIR;
     const resolvedConfigDir =
-      configDir || join(homedir(), ".claude", "mcp-configs");
+      configDir || join(homedir(), CLAUDE_DIR, MCP_CONFIGS_DIR);
     const configs = await scanMcpConfigs(resolvedConfigDir);
 
     if (configs.length === 0) {

--- a/src/mcp-scanner.ts
+++ b/src/mcp-scanner.ts
@@ -2,6 +2,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+  CLAUDE_DIR,
+  CONFIG_FILE_EXTENSION,
+  MCP_CONFIGS_DIR,
+} from "./constants.js";
+import {
   extractServers,
   formatValidationErrors,
   validateMcpConfig,
@@ -28,7 +33,7 @@ export interface McpConfig {
 
 export async function scanMcpConfigs(configDir?: string): Promise<McpConfig[]> {
   const resolvedConfigDir =
-    configDir || join(homedir(), ".claude", "mcp-configs");
+    configDir || join(homedir(), CLAUDE_DIR, MCP_CONFIGS_DIR);
 
   try {
     await stat(resolvedConfigDir);
@@ -48,13 +53,15 @@ export async function scanMcpConfigs(configDir?: string): Promise<McpConfig[]> {
 
   try {
     const files = await readdir(resolvedConfigDir);
-    const jsonFiles = files.filter((file) => file.endsWith(".json"));
+    const jsonFiles = files.filter((file) =>
+      file.endsWith(CONFIG_FILE_EXTENSION),
+    );
 
     // Process files in parallel for better performance
     const configs = await Promise.all(
       jsonFiles.map(async (file): Promise<McpConfig> => {
         const filePath = join(resolvedConfigDir, file);
-        const name = file.replace(".json", "");
+        const name = file.replace(CONFIG_FILE_EXTENSION, "");
 
         try {
           const content = await readFile(filePath, "utf-8");

--- a/src/selection-cache.ts
+++ b/src/selection-cache.ts
@@ -4,9 +4,9 @@ import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import {
+  CACHE_FILE_EXTENSION,
   CACHE_FILE_PREFIX,
   CACHE_VERSION,
-  CONFIG_FILE_EXTENSION,
 } from "./constants.js";
 
 export interface SelectionCache {
@@ -82,7 +82,7 @@ function getCacheFilePath(projectDir: string, configDir: string): string {
   const key = getCacheKey(projectDir, configDir);
   return join(
     getCacheDir(),
-    `${CACHE_FILE_PREFIX}${key}${CONFIG_FILE_EXTENSION}`,
+    `${CACHE_FILE_PREFIX}${key}${CACHE_FILE_EXTENSION}`,
   );
 }
 
@@ -140,8 +140,10 @@ export async function clearCache(): Promise<void> {
   const cacheDir = getCacheDir();
   try {
     const files = await readdir(cacheDir);
-    const cacheFiles = files.filter((file) =>
-      file.startsWith(CACHE_FILE_PREFIX),
+    const cacheFiles = files.filter(
+      (file) =>
+        file.startsWith(CACHE_FILE_PREFIX) &&
+        file.endsWith(CACHE_FILE_EXTENSION),
     );
     await Promise.all(
       cacheFiles.map((file) => rm(join(cacheDir, file), { force: true })),

--- a/src/selection-cache.ts
+++ b/src/selection-cache.ts
@@ -3,9 +3,14 @@ import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import {
+  CACHE_FILE_PREFIX,
+  CACHE_VERSION,
+  CONFIG_FILE_EXTENSION,
+} from "./constants.js";
 
 export interface SelectionCache {
-  version: 1;
+  version: typeof CACHE_VERSION;
   projectDir: string;
   configDir: string;
   lastModified: string;
@@ -75,7 +80,10 @@ function getCacheKey(projectDir: string, configDir: string): string {
 
 function getCacheFilePath(projectDir: string, configDir: string): string {
   const key = getCacheKey(projectDir, configDir);
-  return join(getCacheDir(), `selections-${key}.json`);
+  return join(
+    getCacheDir(),
+    `${CACHE_FILE_PREFIX}${key}${CONFIG_FILE_EXTENSION}`,
+  );
 }
 
 export async function loadSelections(
@@ -88,7 +96,7 @@ export async function loadSelections(
     const content = await readFile(filePath, "utf-8");
     const cache: SelectionCache = JSON.parse(content);
 
-    if (cache.version !== 1) {
+    if (cache.version !== CACHE_VERSION) {
       return new Set();
     }
 
@@ -118,7 +126,7 @@ export async function saveSelections(
   await mkdir(cacheDir, { recursive: true });
 
   const cache: SelectionCache = {
-    version: 1,
+    version: CACHE_VERSION,
     projectDir,
     configDir,
     lastModified: new Date().toISOString(),
@@ -132,7 +140,9 @@ export async function clearCache(): Promise<void> {
   const cacheDir = getCacheDir();
   try {
     const files = await readdir(cacheDir);
-    const cacheFiles = files.filter((file) => file.startsWith("selections-"));
+    const cacheFiles = files.filter((file) =>
+      file.startsWith(CACHE_FILE_PREFIX),
+    );
     await Promise.all(
       cacheFiles.map((file) => rm(join(cacheDir, file), { force: true })),
     );

--- a/src/tui/ConfigSelector.tsx
+++ b/src/tui/ConfigSelector.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useApp, useInput } from "ink";
 import type React from "react";
 import { useCallback, useState } from "react";
+import { DEFAULT_CONFIG_DIR_LABEL } from "../constants.js";
 import type { McpConfig } from "../mcp-scanner.js";
 import { ConfigPreview } from "./ConfigPreview.js";
 import { ErrorDisplay } from "./ErrorDisplay.js";
@@ -149,7 +150,7 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
     return (
       <Box flexDirection="column">
         <Text color="yellow">
-          No valid MCP configs found in {configDir || "~/.claude/mcp-configs/"}
+          No valid MCP configs found in {configDir || DEFAULT_CONFIG_DIR_LABEL}
         </Text>
         <Text>Press any key to launch Claude Code without configs...</Text>
         {invalidConfigs.length > 0 && invalidConfigs[0] && (

--- a/src/tui/ConfigSelector.tsx
+++ b/src/tui/ConfigSelector.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useApp, useInput } from "ink";
 import type React from "react";
 import { useCallback, useState } from "react";
-import { DEFAULT_CONFIG_DIR_LABEL } from "../constants.js";
+import { DEFAULT_CONFIG_DIR_DISPLAY } from "../constants.js";
 import type { McpConfig } from "../mcp-scanner.js";
 import { ConfigPreview } from "./ConfigPreview.js";
 import { ErrorDisplay } from "./ErrorDisplay.js";
@@ -150,7 +150,8 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
     return (
       <Box flexDirection="column">
         <Text color="yellow">
-          No valid MCP configs found in {configDir || DEFAULT_CONFIG_DIR_LABEL}
+          No valid MCP configs found in{" "}
+          {configDir || `${DEFAULT_CONFIG_DIR_DISPLAY}/`}
         </Text>
         <Text>Press any key to launch Claude Code without configs...</Text>
         {invalidConfigs.length > 0 && invalidConfigs[0] && (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { CONFIG_FILE_EXTENSION } from "./constants.js";
 
 export function getPackageVersion(): string {
   const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -18,8 +19,10 @@ export function formatConfigDisplayName(
   filename: string,
   serverNames: string[],
 ): string {
-  // Remove .json extension from filename for display
-  const baseFilename = filename.replace(/\.json$/i, "");
+  // Remove config extension from filename for display
+  const baseFilename = filename.toLowerCase().endsWith(CONFIG_FILE_EXTENSION)
+    ? filename.slice(0, -CONFIG_FILE_EXTENSION.length)
+    : filename;
 
   if (serverNames.length === 0) {
     return baseFilename;


### PR DESCRIPTION
## Summary

- Add shared constants for cache filenames, cache versioning, config file extension, and default config directory names.
- Replace duplicated literals across cache loading, cleanup, scanning, CLI help, and empty-state messages.
- Keep the refactor behavior-preserving while making these values easier to update consistently.

Fixes #56

## Tests

- `pnpm run type-check`
- `pnpm exec biome check src/constants.ts src/selection-cache.ts src/cleanup.ts src/mcp-scanner.ts src/index.ts src/console-selector.ts src/tui/ConfigSelector.tsx src/utils.ts`
- `pnpm test -- src/__tests__/selection-cache.test.ts src/__tests__/cleanup.test.ts src/__tests__/cli-ux.test.ts src/__tests__/utils.test.ts` (60 passed)
- `pnpm run _build:compile`
- `pnpm test` (149 passed, 1 existing Windows permission-denied file test failure at `src/__tests__/mcp-scanner.test.ts:370`; reproduced before this change)